### PR TITLE
Notebook of Implementation Object for pySBOL2

### DIFF
--- a/examples/sbol2/CreatingSBOL2Objects/Implementation.ipynb
+++ b/examples/sbol2/CreatingSBOL2Objects/Implementation.ipynb
@@ -1,0 +1,203 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Creating an Implementation Object\n",
+    "\n",
+    "An `Implementation` object represents an instance of a synthetic biological construct. It primarily describes the **build phase** of a design-build-test-learn workflow. An `Implementation` can refer to a physical laboratory sample that has already been built, or one that is planned to be built in the future. It can also represent virtual or simulated instances.\n",
+    "\n",
+    "Key properties of an `Implementation`:\n",
+    "\n",
+    "- `wasDerivedFrom`: Inherited from the `Identified` superclass, this property is used to link the `Implementation` back to its original design, which can be either a `ModuleDefinition` or a `ComponentDefinition`.\n",
+    "\n",
+    "- `built`: This property is OPTIONAL and links to a `TopLevel` object (either a `ComponentDefinition` or `ModuleDefinition`) that describes the *actual physical structure and/or functional behavior* of the `Implementation`.\n",
+    "    - If `built` refers to the **same** `ComponentDefinition`/`ModuleDefinition` as `wasDerivedFrom`, it implies that the actual structure/function of the `Implementation` matches its original design.\n",
+    "    - If `built` refers to a **different** `ComponentDefinition`/`ModuleDefinition`, it indicates that the `Implementation` has deviated from the original design. This is useful for documenting scenarios like DNA sequencing results not matching the target sequence after assembly.\n",
+    "\n",
+    "This tutorial will demonstrate how to create an `Implementation` that links to an original design and then to a *mutated* or *deviated* actual built construct, illustrating the use of both `wasDerivedFrom` and `built` properties.\n",
+    "\n",
+    "For more details, refer to Section 7.12 \"Implementation\" on page 52 in the SBOL specification (e.g., SBOL 2.3.0 or later)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "import-sbol",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sbol2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup",
+   "metadata": {},
+   "source": [
+    "### Document Setup\n",
+    "First, we'll create an SBOL Document and set a homespace. The homespace defines the base URI for objects created in this document, helping to ensure unique identifiers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "doc-homespace",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "doc = sbol2.Document()\n",
+    "sbol2.setHomespace('http://examples.org/ImplementationNotebook')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "design-cd",
+   "metadata": {},
+   "source": [
+    "### Define the Original Design\n",
+    "We'll start by defining a `ComponentDefinition` that represents our **original design** for a gene, for example, a GFP coding sequence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "gfp-design-cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a Sequence for the original GFP design\n",
+    "gfp_design_sequence = sbol2.Sequence('gfp_design_sequence')\n",
+    "gfp_design_sequence.elements = 'atggactacaaagacgatgacgacaaagctcttttagatccagtaatgaccttcac'\n",
+    "gfp_design_sequence.encoding = sbol2.SBOL_ENCODING_IUPAC\n",
+    "doc.addSequence(gfp_design_sequence)\n",
+    "\n",
+    "# Create the ComponentDefinition for the original GFP design\n",
+    "gfp_design = sbol2.ComponentDefinition('gfp_design')\n",
+    "gfp_design.types =  [sbol2.BIOPAX_DNA]\n",
+    "gfp_design.roles = 'http://identifiers.org/so/SO:0000316' # Role: coding sequence (CDS)\n",
+    "gfp_design.displayId = 'gfp_design'\n",
+    "gfp_design.version = '1.0.0'\n",
+    "gfp_design.sequences = [gfp_design_sequence]\n",
+    "\n",
+    "doc.addComponentDefinition(gfp_design)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "built-cd",
+   "metadata": {},
+   "source": [
+    "### Define the Actual Built Construct (with deviation)\n",
+    "Next, we'll define another `ComponentDefinition` that represents the **actual construct that was built**, which has a slight deviation (e.g., a mutation detected by sequencing) from the original design."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "gfp-mutant-cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a Sequence for the actual built GFP (mutant)\n",
+    "gfp_mutant_sequence = sbol2.Sequence(\n",
+    "    'gfp_mutant_sequence',\n",
+    "    elements='atggactacaaagacgatgacgacaaagctcttttagatccagtaatgaccttaca', # Notice the last three base pairs\n",
+    "    encoding=sbol2.SBOL_ENCODING_IUPAC\n",
+    ")\n",
+    "gfp_mutant_sequence.displayId = 'gfp_mutant_sequence'\n",
+    "gfp_mutant_sequence.version = '1.0.0'\n",
+    "doc.addSequence(gfp_mutant_sequence)\n",
+    "\n",
+    "# Create the ComponentDefinition for the actual built GFP (mutant)\n",
+    "gfp_mutant = sbol2.ComponentDefinition('gfp_mutant')\n",
+    "gfp_mutant.displayId = 'gfp_mutant'\n",
+    "gfp_mutant.types =[ sbol2.BIOPAX_DNA] # Component type: DNA\n",
+    "gfp_mutant.roles=['http://identifiers.org/so/SO:0000316'] # Role: coding sequence (CDS)\n",
+    "gfp_mutant.version = '1.0.0'\n",
+    "gfp_mutant.sequences = [gfp_mutant_sequence] # Link the sequence to the ComponentDefinition\n",
+    "doc.addComponentDefinition(gfp_mutant)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "implementation",
+   "metadata": {},
+   "source": [
+    "### Create the Implementation Object\n",
+    "Now, we will create the `Implementation` object. We will link it to:\n",
+    "\n",
+    "1.  The `gfp_design` using `wasDerivedFrom` (representing the original intent).\n",
+    "2.  The `gfp_mutant` using `built` (representing what was actually constructed and verified)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "create-implementation",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gfp_implementation = sbol2.Implementation('gfp_build_instance')\n",
+    "gfp_implementation.displayId = 'gfp_build_instance'\n",
+    "gfp_implementation.version = '1.0.0'\n",
+    "\n",
+    "# Link to the original design using wasDerivedFrom\n",
+    "gfp_implementation.wasDerivedFrom = gfp_design.identity\n",
+    "\n",
+    "# Link to the actual built construct using built\n",
+    "gfp_implementation.built = gfp_mutant.identity\n",
+    "\n",
+    "doc.addImplementation(gfp_implementation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "validate-save",
+   "metadata": {},
+   "source": [
+    "### Validate and Save the Document\n",
+    "Finally, we'll validate the SBOL document to ensure it's well-formed and then save it to an XML file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "save-doc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report = doc.validate()\n",
+    "\n",
+    "if report == 'Valid.':\n",
+    "    doc.write('Implementation_example.xml')\n",
+    "else:\n",
+    "    print(\"Validation Errors:\")\n",
+    "    print(report)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
It demonstrates linking an original design (`wasDerivedFrom`) to an actual built construct (`built`). The example specifically highlights documenting deviations (e.g., mutations) from the original design. 
Solves #11 